### PR TITLE
Create kevin_rule2022

### DIFF
--- a/rules/kevin_rule2022
+++ b/rules/kevin_rule2022
@@ -1,0 +1,15 @@
+{
+  "rule_type": "excluded",
+  "cpe_filter": {
+    "product": "^zoom$",
+    "vendor": "",
+    "version": "^[0-4]\\.[0-6]",
+    "target_software": "macos"
+  },
+  "app_bundle_filter": {
+    "application_name": "zoom",
+    "version": "^5\\.\\d[1-9]",
+    "vendor_name": ""
+  },
+  "description": "Rule prevents older Zoom cpes from being matched with versions of Zoom above 5.11"
+}


### PR DESCRIPTION
New rule to fix zoom 5.11 bundles from matching with non5.x versions